### PR TITLE
Update VPC checks

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,15 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    aws-sdk (2.6.11)
-      aws-sdk-resources (= 2.6.11)
-    aws-sdk-core (2.6.11)
+    aws-sdk (2.6.35)
+      aws-sdk-resources (= 2.6.35)
+    aws-sdk-core (2.6.35)
+      aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.6.11)
-      aws-sdk-core (= 2.6.11)
-    cucloud (0.7.0)
+    aws-sdk-resources (2.6.35)
+      aws-sdk-core (= 2.6.35)
+    aws-sigv4 (1.0.0)
+    cucloud (0.7.1)
       aws-sdk (~> 2)
       uuid (~> 2.3)
     diff-lcs (1.2.5)

--- a/utilities/check_account/checks/check_account_spec.rb
+++ b/utilities/check_account/checks/check_account_spec.rb
@@ -169,7 +169,7 @@ describe 'Account configuration check' do
   end
 
   describe 'Check VPC configuration' do
-    describe 'comapre nacls' do
+    describe 'Verify that NACL rules are in place' do
       ec2 = Aws::EC2::Client.new
       resp = ec2.describe_regions({})
       resp.regions.each do |region|
@@ -209,20 +209,30 @@ describe 'Account configuration check' do
             )
           end
 
-          it 'should not have any missing rules' do
+          it 'no vpcs should have any missing rules' do
             expect(comparison.find { |x| !x[:missing].empty? }).to be nil
           end
         end
       end
     end
 
-    describe 'flow_logs?' do
-      let(:vpc_utils) do
-        Cucloud::VpcUtils.new
-      end
+    describe 'Verify that flow logs are enabled' do
+      ec2 = Aws::EC2::Client.new
+      resp = ec2.describe_regions({})
+      resp.regions.each do |region|
+        describe "checking #{region.region_name}" do
+          let(:vpc_client) do
+            Aws::EC2::Client.new(region: region.region_name)
+          end
 
-      it 'should return true' do
-        expect(vpc_utils.flow_logs?).to be true
+          let(:vpc_utils) do
+            Cucloud::VpcUtils.new vpc_client
+          end
+
+          it 'all vpcs should have flow logs enabled' do
+            expect(vpc_utils.flow_logs?).to be true
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Bump to use new cucloud_ruby 0.7.1 - improvements to VPC checks.  Add loop over regions for flow logs - check all VPCs in all regions.