### PR TITLE
Extending command-line options for auto_snapshot

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GEM
     aws-sdk-resources (2.6.35)
       aws-sdk-core (= 2.6.35)
     aws-sigv4 (1.0.0)
-    cucloud (0.7.4)
+    cucloud (0.7.5)
       aws-sdk (~> 2)
       uuid (~> 2.3)
     diff-lcs (1.2.5)

--- a/README.md
+++ b/README.md
@@ -113,7 +113,21 @@ If running as a job, we recommend using AWS credentials with minimum privileges 
 docker run -it --rm -v ~/.aws:/root/.aws cutils auto_snapshot
 ```
 
-Utility to snapshot volumes attached to running instances.  The utility takes one integer parameter, the default if nothing is passed is 5.  The utility will create an EBS snapshot of all volumes that do not have a snapshot within the last x days, where x is the parameter passed to the utility.
+Utility to snapshot volumes attached to running instances.  When run with no options specified, will snapshot attached volumes that do not have a snapshot taken within the past **five** days.  Optional parameters include:
+
+   * **--apply-tag** Key=*keyname*,Value=*value*
+      * Adds a tag key/value pair to created snapshots.
+      * Note that tags specified here will **take precedence** over tags with the same key.
+         * Will override values from EBS volume tags that would otherwise have been copied via the **--preserve-tags** argument.
+      * May be specified multiple times to add several tags at once.
+   * **--num-days** *N*
+      * Take snapshots of volumes that do not have a snapshot within the last *N* days.
+      * Defaults to **5** if not specified (see backwards compatibility note below).
+   * **--preserve-tags** *a,b,c*
+      * List of tag keys to preserve, if present, from the EBS volume.
+      * May be specified multiple times to add new keys to the preservation list.
+
+Previous versions of this utility allowed specification of *one integer parameter* to indicate snapshots should be taken of EBS volumes that did not have a snapshot within the past *N* days.  That behavior has been maintained and can be used in lieu of the extended options listed above.  If both **--num-days** and an unnamed integer option are specified, the value from **--num-days** will be used.
 
 If running as a job, we recommend using AWS credentials with minimum privileges -- the following policy example can be used:
 
@@ -138,6 +152,34 @@ If running as a job, we recommend using AWS credentials with minimum privileges 
     ]
 }
 ```
+
+#### Examples
+Take snapshots of all EBS volumes without a snapshot in the past 2 days:
+```
+docker run -it --rm -v ~/.aws:/root/.aws cutils auto_snapshot 2
+```
+
+Take snapshots of all EBS volumes without a snapshot in the past 5 days:
+```
+docker run -it --rm -v ~/.aws:/root/.aws cutils auto_snapshot
+```
+
+Take snapshots of all EBS volumes without a snapshot in the past 5 days, adding tag "Foo=Bar"
+```
+docker run -it --rm -v ~/.aws:/root/.aws cutils auto_snapshot --apply-tag Key=Foo,Value=Bar
+```
+
+Take snapshots of all EBS volumes without a snapshot in the past 5 days, adding tags "Foo=Bar", "Foo2=Bar2" *and* preserving the volumes' "Application", "Cost Center" and "Environment" tags:
+```
+docker run -it --rm -v ~/.aws:/root/.aws cutils auto_snapshot \
+ --apply-tag Key=Foo,Value=Bar \
+ --apply-tag Key=Foo2,Value=Bar2 \
+ --preserve-tags Application \
+ --preserve-tags "Cost Center,Environment"
+```
+
+Note the use of argument quoting to account for whitespace in key/value data.
+
 
 ### Auto Patch
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Utility to snapshot volumes attached to running instances.  When run with no opt
       * List of tag keys to preserve, if present, from the EBS volume.
       * May be specified multiple times to add new keys to the preservation list.
 
-Previous versions of this utility allowed specification of *one integer parameter* to indicate snapshots should be taken of EBS volumes that did not have a snapshot within the past *N* days.  That behavior has been maintained and can be used in lieu of the extended options listed above.  If both **--num-days** and an unnamed integer option are specified, the value from **--num-days** will be used.
+Previous versions of this utility allowed specification of *one integer parameter* to indicate snapshots should be taken of EBS volumes that did not have a snapshot within the past *N* days.  That behavior has been maintained and can be used in lieu of the extended options listed above.  If both **--num-days** and an unnamed integer option are specified, the unnamed argument will be used.
 
 If running as a job, we recommend using AWS credentials with minimum privileges -- the following policy example can be used:
 

--- a/bin/auto_snapshot.rb
+++ b/bin/auto_snapshot.rb
@@ -3,11 +3,11 @@
 require 'cucloud'
 require 'optparse'
 
-default_days = 5
+DEFAULT_DAYS = '5'.freeze
 
 options = {
   add_tags: [],
-  num_days: nil,
+  num_days: DEFAULT_DAYS,
   preserve_tags: []
 }
 
@@ -23,7 +23,7 @@ OptionParser.new do |opts|
   end
   opts.on('--num-days N',
           Integer,
-          "Snapshot volumes without snapshot in past N days (default #{default_days}).") do |item|
+          "Snapshot volumes without snapshot in past N days (default #{DEFAULT_DAYS}).") do |item|
     options[:num_days] = item
   end
   opts.on('--preserve-tags x,y,z',
@@ -43,7 +43,7 @@ end.parse!
 
 # Restore prior version behavior where you could simply provide the number of days
 # as the sole/first argument.
-options[:num_days] = ARGV[0] || 5 if options[:num_days].nil?
+options[:num_days] = ARGV[0] if ARGV.length == 1
 
 ec2_utils = Cucloud::Ec2Utils.new
 snapshots_created = ec2_utils.backup_volumes_unless_recent_backup(options[:num_days].to_i,

--- a/bin/auto_snapshot.rb
+++ b/bin/auto_snapshot.rb
@@ -1,11 +1,54 @@
 #!/usr/bin/env ruby
 
 require 'cucloud'
+require 'optparse'
 
-num_days = ARGV[0] || 5
+default_days = 5
+
+options = {
+  add_tags: [],
+  num_days: nil,
+  preserve_tags: []
+}
+
+OptionParser.new do |opts|
+  opts.on('--apply-tag Key=Foo,Value=Bar',
+          String,
+          'Appy tag to snapshots created.') do |item|
+    match = /^Key=([^,]+),Value=(.+)$/.match(item)
+    unless match && match[1] && match[2] && !match[3]
+      raise "Argument to --add-tag should be the string 'Key=<key>,Value=<value>'"
+    end
+    options[:add_tags] << { key: match[1], value: match[2] }
+  end
+  opts.on('--num-days N',
+          Integer,
+          "Snapshot volumes without snapshot in past N days (default #{default_days}).") do |item|
+    options[:num_days] = item
+  end
+  opts.on('--preserve-tags x,y,z',
+          Array,
+          'Array of tag keys to preserve from volume.') do |item|
+    item.each do |listitm|
+      options[:preserve_tags] << listitm
+    end
+  end
+  opts.on_tail('-h',
+               '--help',
+               'Command help') do
+    puts opts
+    exit
+  end
+end.parse!
+
+# Restore prior version behavior where you could simply provide the number of days
+# as the sole/first argument.
+options[:num_days] = ARGV[0] || 5 if options[:num_days].nil?
 
 ec2_utils = Cucloud::Ec2Utils.new
-snapshots_created = ec2_utils.backup_volumes_unless_recent_backup(num_days.to_i)
+snapshots_created = ec2_utils.backup_volumes_unless_recent_backup(options[:num_days].to_i,
+                                                                  options[:preserve_tags],
+                                                                  options[:add_tags])
 
 snapshots_created.each do |snapshot_created|
   print "#{snapshot_created[:snapshot_id]} was created for volume #{snapshot_created[:volume]}"


### PR DESCRIPTION
This PR addresses #7 by adding extended command-line options for:

- Providing a key list for copying existing tags from EBS volume to the new snapshot
- Providing a list of additional tag key/value pairs to apply to snapshots

The updated logic maintains the previous behavior for those who simply want to call `auto_snapshot` with an integer number of days.  There is also an extended option "--num-days" for those who may prefer use of a named parameter.

Included are a version bump to 0.7.5 for the `cucloud` gem and updates to README.md.
