### PR TITLE
Allow old keys to pass test via ENV'ed whitelist.

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ If running as a job, we recommend using AWS credentials with minimum privileges 
 ```
 docker run -it --rm -e CUTILS_IAM_KEY_WHITELIST="service_acct1,service_acct2" cutils check_account
 ```
-This is useful for users where long-lived IAM keys are by design or may be difficult to rotate.
+Keys that are especially difficult to rotate can be whitelisted with this option. Note, allowing keys to age past 90 days is not a recommended practice. If it is absolutely necessary and instance roles are not an option (i.e., SES SMPT), we recommend that these keys be very tightly scoped in privilege.
 
 ### Auto Snapshot
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,13 @@ If running as a job, we recommend using AWS credentials with minimum privileges 
 }
 ```
 
+#### Check Account Exemptions
+**IAM Key Age**: Users may be exempted from the 90 day IAM key check test by including them in a comma-delimited list passed via the `CUTILS_IAM_KEY_WHITELIST`:
+```
+docker run -it --rm -e CUTILS_IAM_KEY_WHITELIST="service_acct1,service_acct2" cutils check_account
+```
+This is useful for users where long-lived IAM keys are by design or may be difficult to rotate.
+
 ### Auto Snapshot
 
 ```

--- a/utilities/check_account/checks/check_account_spec.rb
+++ b/utilities/check_account/checks/check_account_spec.rb
@@ -6,6 +6,9 @@ PASSWORD_MAXIMUM_AGE_DAYS = 90
 PASSWORD_REUSE = 3
 MAX_KEY_AGE = 90
 HOURS_SINCE_LAST_RULE_EVALUATION = 24
+IAM_KEY_WHITELIST = ENV["CUTILS_IAM_KEY_WHITELIST"].nil? ? \
+  [] : \
+  ENV["CUTILS_IAM_KEY_WHITELIST"].split(',').collect{|i| i.strip}
 
 describe 'Account configuration check' do
   describe 'Check IAM Policies' do
@@ -38,8 +41,10 @@ describe 'Account configuration check' do
       expect(iam_utils.get_users.find { |x| x[:has_password] }).to be_nil
     end
 
-    it "should not have any accesses keys greater than #{MAX_KEY_AGE} days old" do
-      expect(iam_utils.get_active_keys_older_than_n_days(MAX_KEY_AGE)).to be_empty
+    it "any access keys older than #{MAX_KEY_AGE} days should be whitelisted" do
+      iam_utils.get_active_keys_older_than_n_days(MAX_KEY_AGE).each do |key|
+        expect(IAM_KEY_WHITELIST).to include(key[:base_data].user_name)
+      end
     end
 
     describe 'password policy' do

--- a/utilities/check_account/checks/check_account_spec.rb
+++ b/utilities/check_account/checks/check_account_spec.rb
@@ -41,7 +41,7 @@ describe 'Account configuration check' do
       expect(iam_utils.get_users.find { |x| x[:has_password] }).to be_nil
     end
 
-    it "any access keys older than #{MAX_KEY_AGE} days should be whitelisted" do
+    it "should not have any keys older than #{MAX_KEY_AGE} days unless explicitly whitelisted" do
       iam_utils.get_active_keys_older_than_n_days(MAX_KEY_AGE).each do |key|
         expect(IAM_KEY_WHITELIST).to include(key[:base_data].user_name)
       end


### PR DESCRIPTION
Reverse the "old" IAM key test to ensure old key's user are in CUTILS_IAM_KEY_WHITELIST,
allowing an account to have explicitly-allowed list of users with old keys.