### PR TITLE
update checks to correspond with new baseline NACL

### DIFF
--- a/utilities/check_account/checks/check_account_spec.rb
+++ b/utilities/check_account/checks/check_account_spec.rb
@@ -203,10 +203,8 @@ describe 'Account configuration check' do
                 { cidr: '192.35.82.0/24', egress: true, protocol: Cucloud::VpcUtils::PROTOCOL::ALL },
                 { cidr: '192.122.235.0/24', egress: true, protocol: Cucloud::VpcUtils::PROTOCOL::ALL },
                 { cidr: '192.122.236.0/24', egress: true, protocol: Cucloud::VpcUtils::PROTOCOL::ALL },
-                { cidr: '52.200.35.38/32', egress: true, protocol: Cucloud::VpcUtils::PROTOCOL::TCP, from: 88, to: 88 },
-                { cidr: '52.200.35.38/32', egress: true, protocol: Cucloud::VpcUtils::PROTOCOL::UDP, from: 88, to: 88 },
-                { cidr: '52.201.66.104/32', egress: true, protocol: Cucloud::VpcUtils::PROTOCOL::TCP, from: 88, to: 88 },
-                { cidr: '52.201.66.104/32', egress: true, protocol: Cucloud::VpcUtils::PROTOCOL::UDP, from: 88, to: 88 },
+                { cidr: '52.200.35.38/32', egress: true, protocol: Cucloud::VpcUtils::PROTOCOL::ALL,},
+                { cidr: '52.201.66.104/32', egress: true, protocol: Cucloud::VpcUtils::PROTOCOL::ALL},
                 { cidr: '0.0.0.0/0', egress: false, protocol: Cucloud::VpcUtils::PROTOCOL::TCP, from: 22, to: 22 },
                 { cidr: '0.0.0.0/0', egress: false, protocol: Cucloud::VpcUtils::PROTOCOL::TCP, from: 80, to: 80 },
                 { cidr: '0.0.0.0/0', egress: false, protocol: Cucloud::VpcUtils::PROTOCOL::UDP, from: 123, to: 123 },
@@ -220,10 +218,12 @@ describe 'Account configuration check' do
                 { cidr: '192.35.82.0/24', egress: false, protocol: Cucloud::VpcUtils::PROTOCOL::ALL },
                 { cidr: '192.122.235.0/24', egress: false, protocol: Cucloud::VpcUtils::PROTOCOL::ALL },
                 { cidr: '192.122.236.0/24', egress: false, protocol: Cucloud::VpcUtils::PROTOCOL::ALL },
-                { cidr: '52.200.35.38/32', egress: false, protocol: Cucloud::VpcUtils::PROTOCOL::TCP, from: 88, to: 88 },
-                { cidr: '52.200.35.38/32', egress: false, protocol: Cucloud::VpcUtils::PROTOCOL::UDP, from: 88, to: 88 },
-                { cidr: '52.201.66.104/32', egress: false, protocol: Cucloud::VpcUtils::PROTOCOL::TCP, from: 88, to: 88 },
-                { cidr: '52.201.66.104/32', egress: false, protocol: Cucloud::VpcUtils::PROTOCOL::UDP, from: 88, to: 88 }
+                { cidr: '52.200.35.38/32', egress: false, protocol: Cucloud::VpcUtils::PROTOCOL::ALL,},
+                { cidr: '52.201.66.104/32', egress: false, protocol: Cucloud::VpcUtils::PROTOCOL::ALL},
+                { cidr: '35.170.14.255/32', egress: false, protocol: Cucloud::VpcUtils::PROTOCOL::ALL},
+                { cidr: '3.229.3.150/32', egress: false, protocol: Cucloud::VpcUtils::PROTOCOL::ALL},
+                { cidr: '3.228.209.25/32', egress: false, protocol: Cucloud::VpcUtils::PROTOCOL::ALL},
+                { cidr: '3.218.140.210/32', egress: false, protocol: Cucloud::VpcUtils::PROTOCOL::ALL}
               ]
             )
           end

--- a/utilities/check_account/checks/check_account_spec.rb
+++ b/utilities/check_account/checks/check_account_spec.rb
@@ -190,9 +190,12 @@ describe 'Account configuration check' do
           let(:comparison) do
             vpc_utils.compare_nacls(
               [
+                { cidr: '0.0.0.0/0', egress: true, protocol: Cucloud::VpcUtils::PROTOCOL::TCP, from: 22, to: 22 },
                 { cidr: '0.0.0.0/0', egress: true, protocol: Cucloud::VpcUtils::PROTOCOL::TCP, from: 80, to: 80 },
+                { cidr: '0.0.0.0/0', egress: true, protocol: Cucloud::VpcUtils::PROTOCOL::UDP, from: 123, to: 123 },
                 { cidr: '0.0.0.0/0', egress: true, protocol: Cucloud::VpcUtils::PROTOCOL::TCP, from: 443, to: 443 },
                 { cidr: '0.0.0.0/0', egress: true, protocol: Cucloud::VpcUtils::PROTOCOL::TCP, from: 1024, to: 65_535 },
+                { cidr: '0.0.0.0/0', egress: true, protocol: Cucloud::VpcUtils::PROTOCOL::UDP, from: 1024, to: 65_535 },
                 { cidr: '10.0.0.0/8', egress: true, protocol: Cucloud::VpcUtils::PROTOCOL::ALL },
                 { cidr: '128.84.0.0/16', egress: true, protocol: Cucloud::VpcUtils::PROTOCOL::ALL },
                 { cidr: '128.253.0.0/16', egress: true, protocol: Cucloud::VpcUtils::PROTOCOL::ALL },
@@ -200,16 +203,27 @@ describe 'Account configuration check' do
                 { cidr: '192.35.82.0/24', egress: true, protocol: Cucloud::VpcUtils::PROTOCOL::ALL },
                 { cidr: '192.122.235.0/24', egress: true, protocol: Cucloud::VpcUtils::PROTOCOL::ALL },
                 { cidr: '192.122.236.0/24', egress: true, protocol: Cucloud::VpcUtils::PROTOCOL::ALL },
+                { cidr: '52.200.35.38/32', egress: true, protocol: Cucloud::VpcUtils::PROTOCOL::TCP, from: 88, to: 88 },
+                { cidr: '52.200.35.38/32', egress: true, protocol: Cucloud::VpcUtils::PROTOCOL::UDP, from: 88, to: 88 },
+                { cidr: '52.201.66.104/32', egress: true, protocol: Cucloud::VpcUtils::PROTOCOL::TCP, from: 88, to: 88 },
+                { cidr: '52.201.66.104/32', egress: true, protocol: Cucloud::VpcUtils::PROTOCOL::UDP, from: 88, to: 88 },
+                { cidr: '0.0.0.0/0', egress: false, protocol: Cucloud::VpcUtils::PROTOCOL::TCP, from: 22, to: 22 },
                 { cidr: '0.0.0.0/0', egress: false, protocol: Cucloud::VpcUtils::PROTOCOL::TCP, from: 80, to: 80 },
+                { cidr: '0.0.0.0/0', egress: false, protocol: Cucloud::VpcUtils::PROTOCOL::UDP, from: 123, to: 123 },
                 { cidr: '0.0.0.0/0', egress: false, protocol: Cucloud::VpcUtils::PROTOCOL::TCP, from: 443, to: 443 },
                 { cidr: '0.0.0.0/0', egress: false, protocol: Cucloud::VpcUtils::PROTOCOL::TCP, from: 1024, to: 65_535 },
+                { cidr: '0.0.0.0/0', egress: false, protocol: Cucloud::VpcUtils::PROTOCOL::UDP, from: 1024, to: 65_535 },
                 { cidr: '10.0.0.0/8', egress: false, protocol: Cucloud::VpcUtils::PROTOCOL::ALL },
                 { cidr: '128.84.0.0/16', egress: false, protocol: Cucloud::VpcUtils::PROTOCOL::ALL },
                 { cidr: '128.253.0.0/16', egress: false, protocol: Cucloud::VpcUtils::PROTOCOL::ALL },
                 { cidr: '132.236.0.0/16', egress: false, protocol: Cucloud::VpcUtils::PROTOCOL::ALL },
                 { cidr: '192.35.82.0/24', egress: false, protocol: Cucloud::VpcUtils::PROTOCOL::ALL },
                 { cidr: '192.122.235.0/24', egress: false, protocol: Cucloud::VpcUtils::PROTOCOL::ALL },
-                { cidr: '192.122.236.0/24', egress: false, protocol: Cucloud::VpcUtils::PROTOCOL::ALL }
+                { cidr: '192.122.236.0/24', egress: false, protocol: Cucloud::VpcUtils::PROTOCOL::ALL },
+                { cidr: '52.200.35.38/32', egress: false, protocol: Cucloud::VpcUtils::PROTOCOL::TCP, from: 88, to: 88 },
+                { cidr: '52.200.35.38/32', egress: false, protocol: Cucloud::VpcUtils::PROTOCOL::UDP, from: 88, to: 88 },
+                { cidr: '52.201.66.104/32', egress: false, protocol: Cucloud::VpcUtils::PROTOCOL::TCP, from: 88, to: 88 },
+                { cidr: '52.201.66.104/32', egress: false, protocol: Cucloud::VpcUtils::PROTOCOL::UDP, from: 88, to: 88 }
               ]
             )
           end


### PR DESCRIPTION
Hi folks, We have a new AWS suggested NACL definition. It includes access for NTP and Cornell Kerberos servers in AWS. I've updated the check_account NACL rules with this PR, but am not sure that we actually want to merge it to the master. 

My thoughts on this the NACL check in check_account are that check_account shouldn't suggest adding more rules to a NACL that is working just fine for a VPC. 

The NACL check for check_account here won't trigger if you have an allow-all for all-ports for all-sources. So a user can't necessarily feel good about passing the NACL check in check_account.

Regardless, this PR does embody the new suggested NACL rules, if anybody wants it.